### PR TITLE
docs: fix default config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@ These are the defaults:
   identifiers = {"test", "it"}, -- used to identify tests
   prepend = {"describe"}, -- prepend describe blocks
   expressions = {"call_expression"}, -- tree-sitter object used to scan for tests/describe blocks
-  path_to_jest_run = 'jest' -- used to run tests
-  path_to_jest_debug = './node_modules/bin/jest' -- used for debugging
-  terminal_cmd = ":vsplit | terminal" -- used to spawn a terminal for running tests, for debugging refer to nvim-dap's config
+  path_to_jest_run = 'jest', -- used to run tests
+  path_to_jest_debug = './node_modules/bin/jest', -- used for debugging
+  terminal_cmd = ":vsplit | terminal", -- used to spawn a terminal for running tests, for debugging refer to nvim-dap's config
   dap = { -- debug adapter configuration
     type = 'node2',
     request = 'launch',


### PR DESCRIPTION
Fixed missing commas in the default config example.