### PR TITLE
fix: docs path to local jest instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ These are the defaults:
   prepend = {"describe"}, -- prepend describe blocks
   expressions = {"call_expression"}, -- tree-sitter object used to scan for tests/describe blocks
   path_to_jest_run = 'jest', -- used to run tests
-  path_to_jest_debug = './node_modules/bin/jest', -- used for debugging
+  path_to_jest_debug = './node_modules/.bin/jest', -- used for debugging
   terminal_cmd = ":vsplit | terminal", -- used to spawn a terminal for running tests, for debugging refer to nvim-dap's config
   dap = { -- debug adapter configuration
     type = 'node2',


### PR DESCRIPTION
Potentially I would also put `path_to_jest_run` to a local node modules path since people mostly use local jest version and this expects a global jest installation. Let me know. 