### PR TITLE
Support passing the filename at runtime

### DIFF
--- a/lua/jester/init.lua
+++ b/lua/jester/init.lua
@@ -199,10 +199,10 @@ end
 local function run(o)
   local cmd
   local result
-  local file
   if not o then
     o = {}
   end
+  local file = o.file
   local options = vim.tbl_deep_extend('force', global_options, o)
   if options.run_last then
     if options.cache.last_run == nil then


### PR DESCRIPTION
Hi, thanks for the awesome work!

I've trying to extend the debug functionality to support testing with [react-scripts](https://create-react-app.dev/docs/running-tests/) which uses jest under the hood. I'm mostly there using the existing API but there is one part that's tripping me up. Annoyingly it seems our version requires relative filenames to work and this seemed like the easiest way of achieving this.

Happy to look at another approach if you think that might be nicer! Thanks again!