### PR TITLE
optionally escape the regex of a file name

### DIFF
--- a/lua/jester/init.lua
+++ b/lua/jester/init.lua
@@ -231,7 +231,11 @@ local function run(o)
     if not result then return end
   end
   global_options.cache.last_run = { result = result, file = file, cmd = cmd }
-  file = regexEscape(file)
+
+  if options.escapeRegex==nil or options.escapeRegex then
+    file = regexEscape(file)
+  end
+
   if options.func then
     return options.func(vim.tbl_deep_extend('force', options, { result = result, file = file }))
   end


### PR DESCRIPTION
You always regexEscape file paths, but this isn't always needed.