### PR TITLE
Add option to set test timeout when debugging

### DIFF
--- a/lua/jester/init.lua
+++ b/lua/jester/init.lua
@@ -169,6 +169,13 @@ local function debug_jest(o)
       runtimeArgs = {'--inspect-brk', '$path_to_jest', '--no-coverage', '--', '$file'}
     end
   end
+
+  local testTimeout = o.dap.testTimeout
+
+  if testTimeout ~= nil then
+    table.insert(runtimeArgs, 3, "--testTimeout=" .. testTimeout)
+  end
+
   for key, value in pairs(runtimeArgs) do
     if string.match(value, "$result") then
       runtimeArgs[key] = value:gsub("$result", result)


### PR DESCRIPTION
First of all, thanks for sharing this awesome plugin with us.

Regarding my changes: Sometimes tests fail if you take a long time debugging. This option will allow globally setting the test timeout flag when debugging